### PR TITLE
change path for mycroft-core requirements

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,7 +28,7 @@ parts:
 
   mycroft-core:
     plugin: python2
-    requirements: parts/mycroft-core/src/requirements.txt
+    requirements: requirements.txt
     source: https://github.com/MycroftAI/mycroft-core.git
     source-type: git
     source-branch: feature/snapcraft


### PR DESCRIPTION
The `parts/mycroft-core/src` path is implicit. So it doens'nt have to be in the path of the file, else mycroft-core can't be built

Error message : `Could not open requirements file: [Errno 2] Aucun fichier ou dossier de ce type: '/home/winael/Mycroft/snapcraft-mycroft-core/parts/mycroft-core/src/parts/mycroft-core/src/requirements.txt'`
