### PR TITLE
Switch Snap grade to stable allowing promotion above beta channel

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ description: 'Mycroft is a free and open-source intelligent personal assistant a
   the `mycroft.msm` command to list, install, and remove skills.
 
   '
-grade: devel
+grade: stable
 layout:
   /etc/mycroft/mycroft.conf:
     bind-file: $SNAP/etc/mycroft/mycroft.conf


### PR DESCRIPTION
Currently the Snaps are graded: devel meaning they can only be promoted to the beta channel. 

This switches the default config to stable allowing them to be promoted above beta.

In future this should be done dynamically so that only tagged releases are graded stable.