### PR TITLE
Build for 32- and 64-bit x86 and ARM

### DIFF
--- a/snap/local/snapcraft.jsonnet
+++ b/snap/local/snapcraft.jsonnet
@@ -34,6 +34,12 @@ snapcraft {
             bind: "$SNAP_COMMON/vartmp",
         },
     },
+    architecture: [
+        { "build-on": "i386" },
+        { "build-on": "amd64" },
+        { "build-on": "armhf" },
+        { "build-on": "arm64" },
+    ],
     plugs: plugs,
     apps: apps,
     parts: parts,


### PR DESCRIPTION
AMD64 builds are obviously already tested since that's what's in the Snapcraft Store already. I'm going to test the `armhf` build shortly, locally on my Pi. I added in `i386` and `arm64` builds since I figured they're close enough to what was already tested, but I didn't add `s390x` or `ppc64el` (the other two valid snappy architectures) because they're completely disparate architectures and I have no way to test them.

I'm marking this as draft for the time being since it seems like my build is working, but I'm actually still waiting for it to finish so I can test it out.

Fixes #24